### PR TITLE
added translation and number of breaches

### DIFF
--- a/resources/lang/en/validation.php
+++ b/resources/lang/en/validation.php
@@ -1,0 +1,5 @@
+<?php
+
+return [
+    'error_message' => ':attribute was found in at least :num prior security incident(s). Please choose a more secure password.',
+];

--- a/src/PwnedPasswordsServiceProvider.php
+++ b/src/PwnedPasswordsServiceProvider.php
@@ -14,9 +14,19 @@ class PwnedPasswordsServiceProvider extends ServiceProvider
 {
     public function boot()
     {
-        Validator::extend('pwned', Pwned::class, Pwned::VALIDATION_ERROR_MESSAGE);
+        $this->publishes([
+            __DIR__.'/../resources/lang' => base_path('resources/lang/vendor/cookieConsent'),
+        ], 'lang');
+
+        $this->loadTranslationsFrom(__DIR__.'/../resources/lang', 'PwnedPasswords');
+
+        Validator::extend('pwned', Pwned::class);
+
         Validator::replacer('pwned', function ($message, $attribute, $rule, $parameters) {
-            return str_replace(':num', array_shift($parameters) ?? 1, $message);
+            return trans('PwnedPasswords::validation.error_message', [
+                'attribute' => $attribute,
+                'num' => array_shift($parameters) ?? 1
+            ]);
         });
     }
 

--- a/src/PwnedPasswordsServiceProvider.php
+++ b/src/PwnedPasswordsServiceProvider.php
@@ -25,7 +25,7 @@ class PwnedPasswordsServiceProvider extends ServiceProvider
         Validator::replacer('pwned', function ($message, $attribute, $rule, $parameters) {
             return trans('PwnedPasswords::validation.error_message', [
                 'attribute' => $attribute,
-                'num' => array_shift($parameters) ?? 1
+                'num' => array_shift($parameters) ?? 1,
             ]);
         });
     }

--- a/src/Rules/Pwned.php
+++ b/src/Rules/Pwned.php
@@ -47,6 +47,7 @@ class Pwned implements Rule
     {
         try {
             $this->pwned_count = $this->gateway->search($value);
+
             return $this->pwned_count < $this->threshold;
         } catch (Throwable $exception) {
             return app(LookupErrorHandler::class)->handle($exception, $value);

--- a/tests/Feature/PwnedPasswordsServiceProviderTest.php
+++ b/tests/Feature/PwnedPasswordsServiceProviderTest.php
@@ -12,10 +12,13 @@ class PwnedPasswordsServiceProviderTest extends TestCase
     /** @test */
     public function it_should_register_the_validation_error_message_for_our_pwned_rule_with_the_validator(): void
     {
-        $errorMessage = Validator::make(['attribute' => 'P@ssw0rd'], ['attribute' => 'pwned:23'])->errors()->first();
+        $input = ['password' => 'P@ssw0rd'];
+        $rules = ['password' => 'pwned:23'];
+
+        $errorMessage = Validator::make($input, $rules)->errors()->first();
 
         $this->assertEquals(
-            'attribute was found in at least 23 prior security incident(s). Please choose a more secure password.',
+            'password was found in at least 23 prior security incident(s). Please choose a more secure password.',
             $errorMessage
         );
     }

--- a/tests/Feature/PwnedTest.php
+++ b/tests/Feature/PwnedTest.php
@@ -99,6 +99,19 @@ class PwnedTest extends TestCase
     }
 
     /** @test */
+    public function it_should_show_the_exact_number_of_breaches(): void
+    {
+        $objectRuleError = Validator::make(['attr' => 'P@ssw0rd'], ['attr' => new Pwned(75)])->errors()->first();
+        $stringRuleError = Validator::make(['attr' => 'P@ssw0rd'], ['attr' => 'pwned:75'])->errors()->first();
+
+        $this->assertEquals($objectRuleError, $stringRuleError);
+        $this->assertEquals(
+            'attr was found in at least 49938 prior security incident(s). Please choose a more secure password.',
+            $objectRuleError
+        );
+    }
+
+    /** @test */
     public function it_should_pass_the_validation_when_a_network_error_occurs_during_lookup()
     {
         config([

--- a/tests/Feature/PwnedTest.php
+++ b/tests/Feature/PwnedTest.php
@@ -87,14 +87,13 @@ class PwnedTest extends TestCase
     /** @test */
     public function it_should_show_the_validation_error_message_when_used_as_a_rule_object(): void
     {
-        $validator = Validator::make(['my-password' => 'P@ssw0rd'], [
-            'my-password' => new Pwned(75),
-        ]);
+        $input = ['my-password' => 'P@ssw0rd'];
+        $rules = ['my-password' => new Pwned(75)];
 
-        $errorMessage = $validator->errors()->first();
+        $errorMessage = Validator::make($input, $rules)->errors()->first();
 
         $this->assertEquals(
-            'my-password was found in at least 75 prior security incident(s). Please choose a more secure password.',
+            'my-password was found in at least 49938 prior security incident(s). Please choose a more secure password.',
             $errorMessage
         );
     }


### PR DESCRIPTION
Hi Claudio,

I Just went ahead to create the translation. I also added the total number of breaches to the response, so the person can know how many times his/her password has been breached, instead of telling what the threshold is.

To bad the `Validation::extend` only accepts closures, so there we will have to fall back to just telling the threshold. Maybe it's a good idea to get rid of the `Validator::extend` and `Validator::replacer` and let users just use the rule based method instead. like this:

```php
$request->validate([
    'password' => [new Pwned(5)],
]);
```